### PR TITLE
fix api field names in columns

### DIFF
--- a/Socrata.Tests/Tests/Socrata.Tests.SODA.cs
+++ b/Socrata.Tests/Tests/Socrata.Tests.SODA.cs
@@ -33,6 +33,25 @@ namespace Socrata
         }
 
         [Test]
+        [ExpectedException(typeof(Exception))]
+        public void CreateFailsOnInvalidRowIdentifier()
+        {
+            Column id = new Column("id", "INVAID FIELD NAME", SocrataDataType.TEXT);
+            SODASchema schema = new SchemaBuilder()
+                .AddColumn(id)
+                .AddColumn(new Column("text", SocrataDataType.TEXT))
+                .AddColumn(new Column("number", SocrataDataType.NUMBER))
+                .AddColumn(new Column("point", SocrataDataType.POINT))
+                .AddColumn(new Column("date", SocrataDataType.DATETIME, "Data Column Description"))
+                .AddColumn(new Column("bool", SocrataDataType.BOOLEAN))
+                .Build();
+            socrataClient.CreateSodaResourceBuilder("ToDelete")
+                .SetSchema(schema)
+                .SetRowIdentifier(id)
+                .Build();
+        }
+
+        [Test]
         public void CreateDatasetWithRowIdentifier()
         {
             Column id = new Column("id", SocrataDataType.TEXT);
@@ -51,9 +70,9 @@ namespace Socrata
             // Clean it up
             newDataset.Delete();
             // Set it with a non-API Field Name compliance Column
-            Column row_id = new Column("ID", SocrataDataType.TEXT);
+            Column row_id = new Column("ID WITH SPACES", SocrataDataType.TEXT);
             SODASchema new_schema = new SchemaBuilder()
-                .AddColumn(id)
+                .AddColumn(row_id)
                 .AddColumn(new Column("text", SocrataDataType.TEXT))
                 .AddColumn(new Column("number", SocrataDataType.NUMBER))
                 .AddColumn(new Column("point", SocrataDataType.POINT))

--- a/Socrata.Tests/Tests/Socrata.Tests.SODA.cs
+++ b/Socrata.Tests/Tests/Socrata.Tests.SODA.cs
@@ -50,6 +50,22 @@ namespace Socrata
                 .Build();
             // Clean it up
             newDataset.Delete();
+            // Set it with a non-API Field Name compliance Column
+            Column row_id = new Column("ID", SocrataDataType.TEXT);
+            SODASchema new_schema = new SchemaBuilder()
+                .AddColumn(id)
+                .AddColumn(new Column("text", SocrataDataType.TEXT))
+                .AddColumn(new Column("number", SocrataDataType.NUMBER))
+                .AddColumn(new Column("point", SocrataDataType.POINT))
+                .AddColumn(new Column("date", SocrataDataType.DATETIME, "Data Column Description"))
+                .AddColumn(new Column("bool", SocrataDataType.BOOLEAN))
+                .Build();
+            Resource newTestDataset = socrataClient.CreateSodaResourceBuilder("ToDelete")
+                .SetSchema(new_schema)
+                .SetRowIdentifier(row_id)
+                .Build();
+            // Clean it up
+            newTestDataset.Delete();
         }
 
         [Test]

--- a/Socrata/Resource/SodaResourceBuilder.cs
+++ b/Socrata/Resource/SodaResourceBuilder.cs
@@ -61,7 +61,7 @@ namespace Socrata
         /// </summary>
         public SodaResourceBuilder SetRowIdentifier(Column column)
         {
-            this.PrimaryKey = column.columnName;
+            this.PrimaryKey = column.apiFieldName;
             return this;
         }
 

--- a/Socrata/SODA/Models/ColumnMetadata.cs
+++ b/Socrata/SODA/Models/ColumnMetadata.cs
@@ -68,7 +68,7 @@ namespace Socrata.SODA.Schema
 
         public Column ToColumn()
         {
-            return new Column(name, SocrataDataType.Parse(dataTypeName), description, id);
+            return new Column(name, fieldName, SocrataDataType.Parse(dataTypeName), description, id);
         }
     }
 }

--- a/Socrata/SODA/Schema/Column.cs
+++ b/Socrata/SODA/Schema/Column.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Socrata.SODA.Schema
 {
@@ -14,6 +16,7 @@ namespace Socrata.SODA.Schema
 
         public Column(string name, string fieldName, SocrataDataType type, string description, string id)
         {
+            if (!IsFieldNameCompliant(fieldName)) throw new Exception($"{fieldName} is not a valid API field name");
             this.columnName = name;
             this.apiFieldName = fieldName;
             this.type = type;
@@ -21,9 +24,33 @@ namespace Socrata.SODA.Schema
             this.columnId = id;
             this.Metadata = null;
         }
+
+        public Column(string name, string fieldName, SocrataDataType type, string description)
+        {
+            if (!IsFieldNameCompliant(fieldName)) throw new Exception($"{fieldName} is not a valid API field name");
+            this.columnName = name;
+            this.apiFieldName = fieldName;
+            this.type = type;
+            this.description = description;
+            this.columnId = null;
+            this.Metadata = null;
+        }
+
+        public Column(string name, string fieldName, SocrataDataType type)
+        {
+            if (!IsFieldNameCompliant(fieldName)) throw new Exception($"{fieldName} is not a valid API field name");
+            this.columnName = name;
+            this.apiFieldName = fieldName;
+            this.type = type;
+            this.description = null;
+            this.columnId = null;
+            this.Metadata = null;
+        }
+
         public Column(string name, SocrataDataType type, string description)
         {
             this.columnName = name;
+            this.apiFieldName = ToApiFieldName(name);
             this.type = type;
             this.description = description;
             this.columnId = null;
@@ -32,8 +59,8 @@ namespace Socrata.SODA.Schema
 
         public Column(string name, SocrataDataType type)
         {
-            // TODO: names must be fieldName compliant
             this.columnName = name;
+            this.apiFieldName = ToApiFieldName(name);
             this.type = type;
             this.description = null;
             this.columnId = null;
@@ -67,7 +94,7 @@ namespace Socrata.SODA.Schema
             {
                 { "id", this.columnId },
                 { "name", this.columnName },
-                { "fieldName", this.columnName.ToLower() },
+                { "fieldName", this.apiFieldName },
                 { "dataTypeName", this.type.Value },
                 { "description", this.description },
             };
@@ -78,11 +105,20 @@ namespace Socrata.SODA.Schema
             return new Dictionary<string, object>
             {
                 { "name", this.columnName },
-                { "fieldName", this.columnName.ToLower() },
+                { "fieldName", this.apiFieldName },
                 { "dataTypeName", this.type.Value },
                 { "description", this.description },
             };
         }
     
+        public bool IsFieldNameCompliant(string name)
+        {
+            return !Regex.Match(name, "[^a-zA-Z0-9_]").Success;
+        }
+
+        public string ToApiFieldName(string name)
+        {
+            return Regex.Replace(name, @"[^a-zA-Z0-9]", "_").ToLower();
+        }
     }
 }

--- a/Socrata/SODA/Schema/Column.cs
+++ b/Socrata/SODA/Schema/Column.cs
@@ -5,16 +5,17 @@ namespace Socrata.SODA.Schema
     public class Column
     {
         public string columnName {get; set; }
+        public string apiFieldName { get; set; }
         public string description {get; set; }
         public string columnId {get; set; }
         
         public ColumnMetadata Metadata {get; }
         public SocrataDataType type {get; set; }
 
-        public Column(string name, SocrataDataType type, string description, string id)
+        public Column(string name, string fieldName, SocrataDataType type, string description, string id)
         {
-            // TODO: names must be fieldName compliant
             this.columnName = name;
+            this.apiFieldName = fieldName;
             this.type = type;
             this.description = description;
             this.columnId = id;
@@ -41,8 +42,8 @@ namespace Socrata.SODA.Schema
 
         public Column(ColumnMetadata metadata)
         {
-            // TODO: names must be fieldName compliant
             this.columnName = metadata.name;
+            this.apiFieldName = metadata.fieldName;
             this.type = SocrataDataType.Parse(metadata.dataTypeName);
             this.description = metadata.description;
             this.columnId = metadata.id;
@@ -62,23 +63,25 @@ namespace Socrata.SODA.Schema
 
         public Dictionary<string, object> ToColumnDictionary()
         {
-            Dictionary<string, object> col = new Dictionary<string, object>();
-            col.Add("id", this.columnId);
-            col.Add("name", this.columnName);
-            col.Add("fieldName", this.columnName.ToLower());
-            col.Add("dataTypeName", this.type.Value);
-            col.Add("description", this.description);
-            return col;
+            return new Dictionary<string, object>
+            {
+                { "id", this.columnId },
+                { "name", this.columnName },
+                { "fieldName", this.columnName.ToLower() },
+                { "dataTypeName", this.type.Value },
+                { "description", this.description },
+            };
         }
 
         public Dictionary<string, object> ToNewColumnDictionary()
         {
-            Dictionary<string, object> col = new Dictionary<string, object>();
-            col.Add("name", this.columnName);
-            col.Add("fieldName", this.columnName.ToLower());
-            col.Add("dataTypeName", this.type.Value);
-            col.Add("description", this.description);
-            return col;
+            return new Dictionary<string, object>
+            {
+                { "name", this.columnName },
+                { "fieldName", this.columnName.ToLower() },
+                { "dataTypeName", this.type.Value },
+                { "description", this.description },
+            };
         }
     
     }

--- a/Socrata/Socrata.csproj
+++ b/Socrata/Socrata.csproj
@@ -7,7 +7,7 @@
 	
 	  <PackageId>Socrata</PackageId>
 
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
 
     <Description>Socrata .NET Client</Description>
 


### PR DESCRIPTION
Before:
- Column names were implicitly expected to be api field name compliant
- That isn't a reasonable expectation and was failing when trying to set the Row ID

After:
- The Row ID is set by the API field name
- Columns have an optional fieldName parameter in case you want to overload it
- If only the column name is provided, special characters are replaced with `_` and the whole thing is lowercased