### PR TITLE
properly flush the file bytes

### DIFF
--- a/Socrata/DSMAPI/Revision/Revision.cs
+++ b/Socrata/DSMAPI/Revision/Revision.cs
@@ -21,10 +21,17 @@ namespace Socrata.DSMAPI
         }
         private SourceResponse CreateSource(Dictionary<string, string> source)
         {
-            System.Console.WriteLine(string.Join(Environment.NewLine, source));
-            Dictionary<string, object> sourceType = new Dictionary<string, object>();
-            sourceType.Add("source_type", source);
-            System.Console.WriteLine(string.Join(Environment.NewLine, sourceType));
+            Console.WriteLine(string.Join(Environment.NewLine, source));
+            Dictionary<string, object> sourceType = new Dictionary<string, object>
+            {
+                { "source_type", source }
+            };
+            Dictionary<string, bool> parseOptions = new Dictionary<string, bool>
+            {
+                { "parse_source", true }
+            };
+            sourceType.Add("parse_options", parseOptions);
+            Console.WriteLine(string.Join(Environment.NewLine, sourceType));
             SourceResponse result = HttpClient.PostJson<SourceResponse>(Links.CreateSource, sourceType);
             return result;
         }

--- a/Socrata/DSMAPI/Source/ByteSink.cs
+++ b/Socrata/DSMAPI/Source/ByteSink.cs
@@ -27,6 +27,7 @@ namespace Socrata.DSMAPI {
                     resp = WriteBytes(b);
                     this.seq_num += 1;
                     this.byte_offset += b.Length;
+                    b = new byte[this.preferred_chunk_size];
                 }
             }
 

--- a/Socrata/Http/SocrataHttpClient.cs
+++ b/Socrata/Http/SocrataHttpClient.cs
@@ -96,8 +96,15 @@ namespace Socrata.HTTP
         public T GetJson<T>(string endpoint) where T : class
         {
             var resp = Get(endpoint);
-            var result = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(resp.Content.ReadAsStringAsync().Result);
-            return result;
+            var s = resp.Content.ReadAsStringAsync().Result;
+            try {
+                var result = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(s);
+                return result;
+            } catch (Exception e) {
+                Console.WriteLine(s);
+                return null;
+            }
+
         }
 
         public T GetJson<T>(Uri uri) where T : class

--- a/Socrata/Socrata.csproj
+++ b/Socrata/Socrata.csproj
@@ -7,7 +7,7 @@
 	
 	  <PackageId>Socrata</PackageId>
 
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
 
     <Description>Socrata .NET Client</Description>
 


### PR DESCRIPTION
Problem:
- When a file was >2MB, the file stream iterator would not flush the bytes properly

Fix:
- Flush the byte array after the bytes have been successfully written to Socrata
- Bump minor version