### PR TITLE
Return the error message if there is one

### DIFF
--- a/Socrata/Http/SocrataHttpClient.cs
+++ b/Socrata/Http/SocrataHttpClient.cs
@@ -31,7 +31,12 @@ namespace Socrata.HTTP
             if(!dangerously) {
                 if(!resp.IsSuccessStatusCode)
                 {
-                    Console.WriteLine(resp.Content.ReadAsStringAsync().Result);
+                    try {
+                        var message = resp.Content.ReadAsStringAsync().Result;
+                        Console.WriteLine(message);
+                    } catch {
+                        Console.WriteLine("No failure message provided or server returned no data");
+                    }
                     resp.EnsureSuccessStatusCode();
                 }
             }


### PR DESCRIPTION
If the server doesn't respond with any data the HTTP error isn't surfaced because ReadStringAsync will fail to read any content.

Before:
- Message was printed from the result

After:
- We try to print the message, but if there isn't a message, we still surface the HTTPException